### PR TITLE
Use websocket transport

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -37,6 +37,7 @@ denied them the data during the event.
 I've found several possible ways where you can connect to the Socket.IO
 server.
 
+- [scorebot-lb.hltv.org:443](#)
 - [scorebot-secure.hltv.org:443](#)
 - [cf1-scorebot.hltv.org:443](#)
 - [cf2-scorebot.hltv.org:443](#)

--- a/scorebot/scorebot.py
+++ b/scorebot/scorebot.py
@@ -47,7 +47,7 @@ class Livescore:
     TEAM_COUNTER_TERRORIST = "CT"
 
     def __init__(
-        self, list_id=None, socket_uri="https://scorebot-secure.hltv.org"
+        self, list_id=None, socket_uri="https://scorebot-lb.hltv.org"
     ):
         self.list_id = list_id
         self.socket_uri = socket_uri
@@ -300,6 +300,6 @@ class Livescore:
             self.on_event[self.EVENT_SCOREBOARD](scoreboard_data)
 
         # Connect to the scorebot URI.
-        await sio.connect(self.socket_uri)
+        await sio.connect(self.socket_uri, transports="websocket")
 
         return sio


### PR DESCRIPTION
Don't use polling before upgrading, this will make the server reject the
request.

Update documentation and default hostname since this is what's currently
being used by HLTV.

Closes #4 

---

I want to dig deeper into this when possible, it's confusing that inspecting the network graph at HLTV.org they're using the polling transport with [their scorebot API](https://scorebot-secure.hltv.org/scorebotClientApi.js?v9). 